### PR TITLE
Support for new deployment method NIO-1193

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -44,7 +44,7 @@ class DeploymentManager(CoreComponent):
         self._api_proxy = None
         self._configuration_manager = None
 
-        self.config_api_url_prefix = None
+        self._config_api_url_prefix = None
         self._api_key = None
         self._instance_id = None
 
@@ -78,7 +78,7 @@ class DeploymentManager(CoreComponent):
         self._api_key_manager = self.get_dependency('APIKeyManager')
 
         # fetch component settings
-        self.config_api_url_prefix = \
+        self._config_api_url_prefix = \
             Settings.get("configuration", "config_api_url_prefix",
                          fallback="https://api.n.io/v1")
 
@@ -103,7 +103,7 @@ class DeploymentManager(CoreComponent):
         Begins polling job if it is set
         """
         super().start()
-        self._api_proxy = DeploymentProxy(self.config_api_url_prefix, self)
+        self._api_proxy = DeploymentProxy(self._config_api_url_prefix, self)
         self._config_handler = DeploymentHandler(self)
         self._rest_manager.add_web_handler(self._config_handler)
 

--- a/manager.py
+++ b/manager.py
@@ -45,9 +45,6 @@ class DeploymentManager(CoreComponent):
         self._configuration_manager = None
 
         self._config_api_url_prefix = None
-        self._api_key = None
-        self._instance_id = None
-
         self._config_id = None
         self._config_version_id = None
 

--- a/manager.py
+++ b/manager.py
@@ -44,7 +44,7 @@ class DeploymentManager(CoreComponent):
         self._api_proxy = None
         self._configuration_manager = None
 
-        self._config_api_url_prefix = None
+        self.config_api_url_prefix = None
         self._api_key = None
         self._instance_id = None
 
@@ -75,9 +75,10 @@ class DeploymentManager(CoreComponent):
         self._rest_manager = self.get_dependency('RESTManager')
         self._configuration_manager = \
             self.get_dependency('ConfigurationManager')
+        self._api_key_manager = self.get_dependency('APIKeyManager')
 
         # fetch component settings
-        self._config_api_url_prefix = \
+        self.config_api_url_prefix = \
             Settings.get("configuration", "config_api_url_prefix",
                          fallback="https://api.n.io/v1")
 
@@ -92,19 +93,8 @@ class DeploymentManager(CoreComponent):
             "configuration", "start_stop_services", fallback=True)
         self._delete_missing = Settings.getboolean(
             "configuration", "delete_missing", fallback=True)
-
-        # fetch instance specific settings
-        self._api_key = Persistence().load(
-            "api_key",
-            default=Settings.get("configuration", "instance_api_key"))
-        self._instance_id = Persistence().load(
-            "instance_id",
-            default=Settings.get("configuration", "instance_id"))
-
-        # config autonomy specific settings
-        self._poll_interval = Settings.getint("configuration",
-                                              "config_poll_interval",
-                                              fallback=0)
+        self._poll_interval = Settings.getint(
+            "configuration", "config_poll_interval", fallback=0)
 
     def start(self):
         """ Starts component
@@ -113,11 +103,10 @@ class DeploymentManager(CoreComponent):
         Begins polling job if it is set
         """
         super().start()
-        self._api_proxy = DeploymentProxy(
-            self._config_api_url_prefix, self._api_key, self._instance_id)
+        self._api_proxy = DeploymentProxy(self.config_api_url_prefix, self)
         self._config_handler = DeploymentHandler(self)
         self._rest_manager.add_web_handler(self._config_handler)
-    
+
         if self._poll_interval:
             self._poll_job = Job(self._run_config_update,
                                  timedelta(seconds=self._poll_interval),
@@ -127,15 +116,24 @@ class DeploymentManager(CoreComponent):
         """ Stops component
         """
         self._rest_manager.remove_web_handler(self._config_handler)
-        
+
         if self._poll_job:
             self._poll_job.cancel()
             self._poll_job = None
-        
+
         super().stop()
+
+    @property
+    def api_key(self):
+        return self._api_key_manager.api_key
+
+    @property
+    def instance_id(self):
+        return self._api_key_manager.instance_id
 
     def _run_config_update(self):
         """Callback function to run update at each polling interval """
+        self.logger.debug("Checking for latest configuration")
         # Assume our current "user" is the core's service account
         set_user(CoreServiceAccount())
 
@@ -143,52 +141,46 @@ class DeploymentManager(CoreComponent):
         # should be running
         ids = self._api_proxy.get_instance_config_ids()
         if ids is None:
-            msg = "Failure to retrieve expected instance version " \
-                  "from nio API return"
-            self.logger.error(msg)
-            raise RuntimeError(msg)
+            # It didn't report any IDs to update to, so ignore
+            return
 
+        self.logger.debug("Desired configuration: {}".format(ids))
         config_id = ids.get("instance_configuration_id")
         config_version_id = ids.get("instance_configuration_version_id")
-        # Update instance configuration if versions differ
-        if config_id != self.config_id or \
-           config_version_id != self.config_version_id:
-            deployment_id = ids.get("deployment_id")
-            result = self.update_configuration(
-                config_id, config_version_id, deployment_id)
-            # instance is now running this configuration so persist this fact
-            self.config_id = config_id
-            self.config_version_id = config_version_id
 
-            # gather and report any possible errors
-            error_messages = self._get_potential_errors_messages(result)
-            error_count = len(error_messages)
-            if error_count:
-                error_messages = ",".join(error_messages)
-                self.logger.error(
-                    "{} errors were encountered during update, {}".format(
-                        error_count, error_messages))
-                # notify failure
-                self._api_proxy.set_reported_configuration(
-                    config_id, config_version_id,
-                    deployment_id,
-                    self.Status.failed.name,
-                    "Failed to update, these errors were encountered, " +
-                    error_messages)
-                return
+        if config_id == self.config_id and \
+           config_version_id == self.config_version_id:
+            self.logger.debug(
+                "No change detected from current version, skipping")
+            return
 
-            # report success and new instance config ids
-            self._api_proxy.set_reported_configuration(
-                config_id, config_version_id, deployment_id,
-                self.Status.success.name,
-                "updated services and blocks")
-            self.logger.info("Configuration was updated, {}".format(result))
+        self.logger.info(
+            "New configuration detected...updating to config ID {} "
+            "version {}".format(config_id, config_version_id))
+        deployment_id = ids.get("deployment_id")
+        result = self.update_configuration(
+            config_id, config_version_id, deployment_id)
 
-    def update_configuration(self, config_id, config_version_id, deployment_id):
+        self.logger.info("Configuration was updated: {}".format(result))
+
+    def update_configuration(
+            self,
+            config_id,
+            config_version_id,
+            deployment_id=None):
+        """ Update this instance to a given config/version ID.
+
+        Args:
+            config_id: The ID of the instance configuration to use
+            config_version_id: The version ID of the instance config
+            deployment_id: The optional deployment ID to set the status for
+
+        Returns:
+            result (dict): The result of the instance update call
+        """
         # grab new configuration
-        configuration = \
-            self._api_proxy.get_configuration(config_id,
-                                              config_version_id)
+        configuration = self._api_proxy.get_configuration(
+            config_id, config_version_id)
         if configuration is None or "configuration_data" not in configuration:
             msg = "configuration_data entry missing in nio API return"
             self.logger.error(msg)
@@ -197,19 +189,47 @@ class DeploymentManager(CoreComponent):
         configuration_data = json.loads(configuration["configuration_data"])
         # notify configuration acceptance
         self._api_proxy.set_reported_configuration(
-            config_id, config_version_id, deployment_id,
+            config_id,
+            config_version_id,
+            deployment_id,
             self.Status.accepted.name,
             "Services and Blocks configuration was accepted, "
             "proceeding with update")
 
         # perform update
         result = self._configuration_manager.update(
-            configuration_data, self._start_stop_services, self._delete_missing)
+            configuration_data,
+            self._start_stop_services,
+            self._delete_missing)
+
+        # instance is now running this configuration so persist this fact
+        self.config_id = config_id
+        self.config_version_id = config_version_id
+
+        error_messages = self._get_potential_errors_messages(result)
+        if error_messages:
+            # notify failure
+            self._api_proxy.set_reported_configuration(
+                config_id,
+                config_version_id,
+                deployment_id,
+                self.Status.failed.name,
+                "Failed to update, these errors were encountered: {}".format(
+                    error_messages))
+        else:
+            # report success and new instance config ids
+            self._api_proxy.set_reported_configuration(
+                config_id,
+                config_version_id,
+                deployment_id,
+                self.Status.success.name,
+                "Successfully updated services and blocks")
+            self.logger.info("Configuration was updated, {}".format(result))
 
         return result
 
     def _get_potential_errors_messages(self, result):
-        # maintain a list of errors encountered if any
+        """Return any error messages contained in a result"""
         messages = []
         for key in result.keys():
             errors = result.get(key, {}).get("error", [])
@@ -226,6 +246,11 @@ class DeploymentManager(CoreComponent):
                 # do not let errors go unnoticed
                 self.logger.error("{} error: {}".format(key, errors))
 
+        messages = ",".join(messages)
+        if messages:
+            self.logger.error(
+                "{} errors were encountered during update: {}".format(
+                    len(messages), messages))
         return messages
 
     @property
@@ -239,8 +264,7 @@ class DeploymentManager(CoreComponent):
             self._config_id = config_id
             # persist value so that it can be read eventually
             # when component starts again
-            Persistence().save(self.config_id,
-                               "configuration_id")
+            Persistence().save(self.config_id, "configuration_id")
 
     @property
     def config_version_id(self):
@@ -254,5 +278,5 @@ class DeploymentManager(CoreComponent):
             self._config_version_id = config_version_id
             # persist value so that it can be read eventually
             # when component starts again
-            Persistence().save(self.config_version_id,
-                               "configuration_version_id")
+            Persistence().save(
+                self.config_version_id, "configuration_version_id")

--- a/proxy.py
+++ b/proxy.py
@@ -1,4 +1,5 @@
 import requests
+from requests.exceptions import HTTPError
 
 from nio.util.logging import get_nio_logger
 
@@ -7,13 +8,12 @@ class DeploymentProxy(object):
     """ Serves as a Proxy to make Product API configuration requests
     """
 
-    def __init__(self, url_prefix, api_key, instance_id):
+    def __init__(self, url_prefix, manager):
         super().__init__()
-        self.logger = get_nio_logger("ConfigProxy")
+        self.logger = get_nio_logger("DeploymentManager")
 
         self._url_prefix = url_prefix
-        self._api_key = api_key
-        self._instance_id = instance_id
+        self._manager = manager
 
     def get_instance_config_ids(self):
         """ Gets the conf id and conf version id the instance should be running
@@ -26,36 +26,56 @@ class DeploymentProxy(object):
             }
         """
         url = "{}/instances/{}/configuration".format(
-            self._url_prefix, self._instance_id)
-        return self._request(
-            requests.get, url, self._api_key,
-            "Failed to get configuration version the instance "
-            "should be running")
+            self._url_prefix, self._manager.instance_id)
+        try:
+            return self._request(
+                fn=requests.get,
+                url=url,
+                failed_msg=("Failed to get configuration version the instance "
+                            "should be running")
+            )
+        except HTTPError as e:
+            if e.response.status_code == 400:
+                # This likely indicates that no desired configuration was
+                # found for this particular instance ID, nothing to cause alarm
+                self.logger.info(e.response.json().get("message"))
+            else:
+                raise
 
-    def set_reported_configuration(self, config_id, config_version_id,
-                                   deployment_id, status, message):
+    def set_reported_configuration(
+            self,
+            config_id,
+            config_version_id,
+            deployment_id=None,
+            status="",
+            message=""):
         """ Posts instance config ids and status
 
         Args:
             config_id (str): instance configuration id
             config_version_id (str): instance configuration version id
-            deployment_id (str): deployment id
+            deployment_id (str): Optional deployment id that the status
+                and message belongs to
             status (str): deployment status
             message (str): deployment message
         """
 
         url = "{}/instances/{}/configuration".format(
-            self._url_prefix, self._instance_id)
+            self._url_prefix, self._manager.instance_id)
+        body = {
+            "reported_configuration_id": config_id,
+            "reported_configuration_version_id": config_version_id,
+            "status": status,
+            "message": message,
+        }
+        if deployment_id is not None:
+            body["deployment_id"] = deployment_id
         return self._request(
-            requests.post, url, self._api_key,
-            "Failed to post new configuration version instance is running",
-            json={
-                "reported_configuration_id": config_id,
-                "reported_configuration_version_id": config_version_id,
-                "deployment_id": deployment_id,
-                "status": status,
-                "message": message
-            }
+            fn=requests.post,
+            url=url,
+            failed_msg=("Failed to post new configuration version "
+                        "instance is running"),
+            json=body
         )
 
     def get_configuration(self, config_id, config_version_id):
@@ -82,28 +102,18 @@ class DeploymentProxy(object):
         url = "{}/instance_configurations/{}/versions/{}".format(
             self._url_prefix, config_id, config_version_id)
         return self._request(
-            requests.get, url, self._api_key,
-            "Failed to get instance configuration")
+            fn=requests.get,
+            url=url,
+            failed_msg="Failed to get instance configuration")
 
-    def _request(self, fn, url, api_key, failed_msg, **kwargs):
-        try:
-            response = fn(
-                url,
-                headers=self._get_headers(api_key),
-                **kwargs
-            )
-            response.raise_for_status()
-            if response.ok:
-                try:
-                    return response.json()
-                except ValueError:  # pragma no cover
-                    return None
-        except requests.exceptions.ConnectionError:  # pragma no cover
-            self.logger.exception(failed_msg)
-
-    @staticmethod
-    def _get_headers(api_key):
-        return {
-            "authorization": "apikey {}".format(api_key),
+    def _request(self, fn, url, failed_msg, **kwargs):
+        headers = {
+            "authorization": "apikey {}".format(self._manager.api_key),
             "content-type": "application/json"
         }
+        try:
+            response = fn(url, headers=headers, **kwargs)
+        except requests.exceptions.ConnectionError:  # pragma no cover
+            self.logger.exception(failed_msg)
+        response.raise_for_status()
+        return response.json()

--- a/proxy.py
+++ b/proxy.py
@@ -1,5 +1,5 @@
 import requests
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError, ConnectionError
 
 from nio.util.logging import get_nio_logger
 
@@ -113,7 +113,7 @@ class DeploymentProxy(object):
         }
         try:
             response = fn(url, headers=headers, **kwargs)
-        except requests.exceptions.ConnectionError:  # pragma no cover
+        except ConnectionError:
             self.logger.exception(failed_msg)
         response.raise_for_status()
         return response.json()

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -46,8 +46,6 @@ class TestDeploymentManager(NIOTestCase):
         cfg_version_id = "cfg_version_id"
         deployment_id = "dep_id"
 
-        manager._api_key = "apikey"
-        manager._instance_id = "my_instance_id"
         manager._config_api_url_prefix = "api_url_prefix"
         manager._config_id = cfg_id
         manager._config_version_id = cfg_version_id

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,5 +1,5 @@
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, patch, ANY
 
 from nio.modules.web import RESTHandler
 from niocore.core.context import CoreContext
@@ -39,6 +39,8 @@ class TestDeploymentManager(NIOTestCase):
 
     def test_update_with_version(self):
         manager = DeploymentManager()
+        manager._configuration_manager = MagicMock()
+        core_updater = manager._configuration_manager.update
 
         cfg_id = "cfg_id"
         cfg_version_id = "cfg_version_id"
@@ -47,8 +49,8 @@ class TestDeploymentManager(NIOTestCase):
         manager._api_key = "apikey"
         manager._instance_id = "my_instance_id"
         manager._config_api_url_prefix = "api_url_prefix"
-        manager._config_id = "cfg_id"
-        manager._config_version_id = "cfg_version_id"
+        manager._config_id = cfg_id
+        manager._config_version_id = cfg_version_id
         manager._api_proxy = MagicMock()
 
         failed_resource_properties = {
@@ -77,18 +79,23 @@ class TestDeploymentManager(NIOTestCase):
                 ]
             }
         }
-        manager.update_configuration = MagicMock(
-            return_value = update_result)
+        core_updater.return_value = update_result
+        manager._api_proxy.get_configuration.return_value = {
+            "configuration_data": json.dumps({
+                "blocks": {},
+                "services": {},
+                "blockTypes": {},
+            })
+        }
 
         # Test that update isn't called when latest route fails
         manager._api_proxy.get_instance_config_ids.return_value = None
 
-        with self.assertRaises(RuntimeError):
-            manager._run_config_update()
-            self.assertEqual(
-                manager._api_proxy.get_instance_config_ids.call_count, 1)
-            self.assertEqual(manager.update_configuration.call_count, 0)
-        
+        manager._run_config_update()
+        self.assertEqual(
+            manager._api_proxy.get_instance_config_ids.call_count, 1)
+        self.assertEqual(core_updater.call_count, 0)
+
         manager._api_proxy.reset_mock()
         # Test that update isn't called with the same version id
         manager._api_proxy.get_instance_config_ids.return_value = {
@@ -101,7 +108,7 @@ class TestDeploymentManager(NIOTestCase):
         self.assertEqual(
             manager._api_proxy.get_instance_config_ids.call_count, 1)
         manager._api_proxy.get_instance_config_ids.assert_called_once_with()
-        self.assertEqual(manager.update_configuration.call_count, 0)
+        self.assertEqual(core_updater.call_count, 0)
 
         manager._api_proxy.reset_mock()
         # Test update called with a new config version id
@@ -113,21 +120,11 @@ class TestDeploymentManager(NIOTestCase):
         }
         # run an update that reports an error
         manager._run_config_update()
-        self.assertEqual(manager.update_configuration.call_count, 1)
-        # assert update call
-        manager.update_configuration.assert_called_once_with(
-            cfg_id, cfg_version_id, deployment_id)
-        # assert api notification
-        expected_message = "Failed to update, these errors were encountered, " \
-                           "Failed to install services, {}," \
-                           "Failed to install blockTypes, {}".\
-            format(json.dumps(failed_resource_properties),
-                   update_result["blockTypes"]["error"][0])
-        manager._api_proxy.set_reported_configuration.assert_called_once_with(
+        self.assertEqual(core_updater.call_count, 1)
+        manager._api_proxy.set_reported_configuration.assert_called_with(
             cfg_id, cfg_version_id, deployment_id,
             DeploymentManager.Status.failed.name,
-            expected_message
-        )
+            ANY)
 
         # clear out errors
         update_result["services"]["error"] = []
@@ -141,12 +138,11 @@ class TestDeploymentManager(NIOTestCase):
         }
         # run an update with no error
         manager._run_config_update()
-        self.assertEqual(manager.update_configuration.call_count, 2)
-        success_message = "updated services and blocks"
+        self.assertEqual(core_updater.call_count, 2)
         manager._api_proxy.set_reported_configuration.assert_any_call(
             cfg_id, cfg_version_id, deployment_id,
             DeploymentManager.Status.success.name,
-            success_message
+            ANY
         )
 
     def test_update_config(self):
@@ -158,7 +154,7 @@ class TestDeploymentManager(NIOTestCase):
         manager._delete_missing = False
         manager._config_id = "cfg_id"
         manager._config_version_id = "cfg_version_id_1"
-        
+
         # Mock methods/dependencies
         manager._api_proxy = MagicMock()
         manager._configuration_manager = MagicMock()
@@ -178,8 +174,8 @@ class TestDeploymentManager(NIOTestCase):
         self.assertEqual(call_args[1], True)
         self.assertEqual(call_args[2], False)
 
-        # show that component is not tied to any configuration data fields other
-        # than expecting a 'configuration_data' entry
+        # show that component is not tied to any configuration data fields
+        # other than expecting a 'configuration_data' entry
         manager._api_proxy.get_configuration.return_value = {
             "a_field": "a_field_data"
         }

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -7,71 +7,86 @@ from ..proxy import DeploymentProxy
 from nio.testing.test_case import NIOTestCase
 
 
+@patch("{}.requests".format(DeploymentProxy.__module__))
 class TestDeploymentProxy(NIOTestCase):
 
-    def test_get_instance_config_ids(self):
-        proxy = DeploymentProxy("api_url_prefix", "token", "my_instance_id")
-        with patch("{}.requests".format(DeploymentProxy.__module__)) \
-                as request_patch:
-            proxy.get_instance_config_ids()
-            headers = proxy._get_headers("token")
+    def setUp(self):
+        super().setUp()
+        manager = Mock()
+        manager.api_key = "token"
+        manager.instance_id = "my_instance_id"
+        self._proxy = DeploymentProxy("api_url_prefix", manager)
 
-            test_headers = {
-                "authorization": "apikey token",
-                "content-type": "application/json"
-            }
-            self.assertEqual(headers, test_headers)
+    def test_get_instance_config_ids(self, mock_req):
+        self._proxy.get_instance_config_ids()
+        expected_headers = {
+            "authorization": "apikey token",
+            "content-type": "application/json"
+        }
 
-            desired_url = \
-                "api_url_prefix/instances/my_instance_id/configuration"
-            request_patch.get.assert_called_with(desired_url,
-                                                 headers=headers)
+        desired_url = "api_url_prefix/instances/my_instance_id/configuration"
+        mock_req.get.assert_called_with(desired_url, headers=expected_headers)
 
-    def test_notify_instance_config_ids(self):
-        proxy = DeploymentProxy("api_url_prefix", "token", "my_instance_id")
-
+    def test_notify_instance_config_ids(self, mock_req):
         cfg_id = "cfg_id"
         cfg_version_id = "cfg_version_id"
         deployment_id = "dep_id"
         status = "status"
         message = "message"
+        expected_headers = {
+            "authorization": "apikey token",
+            "content-type": "application/json"
+        }
 
-        with patch("{}.requests".format(DeploymentProxy.__module__)) \
-                as request_patch:
+        self._proxy.set_reported_configuration(
+            cfg_id, cfg_version_id, deployment_id, status, message)
 
-            proxy.set_reported_configuration(
-                cfg_id, cfg_version_id, deployment_id, status, message)
-            headers = proxy._get_headers("token")
-
-            desired_url = \
-                "api_url_prefix/instances/my_instance_id/configuration"
-            request_patch.post.assert_called_with(
-                desired_url, headers=headers,
-                json={
-                    'reported_configuration_id': cfg_id,
-                    'reported_configuration_version_id': cfg_version_id,
-                    'deployment_id': deployment_id,
-                    'status': status,
-                    'message': message
-                }
-            )
-
-    def test_get_configuration(self):
-        proxy = DeploymentProxy("api", "token", "instance_id")
-        with patch("{}.requests".format(DeploymentProxy.__module__)) \
-                as request_patch:
-            proxy.get_configuration("config_id",
-                                    "config_version_id",
-                                    )
-            headers = proxy._get_headers("token")
-
-            test_headers = {
-                "authorization": "apikey token",
-                "content-type": "application/json"
+        desired_url = \
+            "api_url_prefix/instances/my_instance_id/configuration"
+        mock_req.post.assert_called_with(
+            desired_url,
+            headers=expected_headers,
+            json={
+                'reported_configuration_id': cfg_id,
+                'reported_configuration_version_id': cfg_version_id,
+                'deployment_id': deployment_id,
+                'status': status,
+                'message': message
             }
-            self.assertEqual(headers, test_headers)
+        )
 
-            desired_url = "api/instance_configurations/" \
-                          "config_id/versions/config_version_id"
-            request_patch.get.assert_called_with(desired_url,
-                                                 headers=headers)
+    def test_notify_instance_config_ids_without_deployment(self, mock_req):
+        cfg_id = "cfg_id"
+        cfg_version_id = "cfg_version_id"
+        status = "status"
+        message = "message"
+        expected_headers = {
+            "authorization": "apikey token",
+            "content-type": "application/json"
+        }
+
+        self._proxy.set_reported_configuration(
+            cfg_id, cfg_version_id, None, status, message)
+
+        desired_url = \
+            "api_url_prefix/instances/my_instance_id/configuration"
+        mock_req.post.assert_called_with(
+            desired_url,
+            headers=expected_headers,
+            json={
+                'reported_configuration_id': cfg_id,
+                'reported_configuration_version_id': cfg_version_id,
+                'status': status,
+                'message': message
+            }
+        )
+
+    def test_get_configuration(self, mock_req):
+        self._proxy.get_configuration("config_id", "config_version_id")
+        expected_headers = {
+            "authorization": "apikey token",
+            "content-type": "application/json"
+        }
+        desired_url = ("api_url_prefix/instance_configurations/config_id/"
+                       "versions/config_version_id")
+        mock_req.get.assert_called_with(desired_url, headers=expected_headers)


### PR DESCRIPTION
This PR does the following:
1. Fixes the component (primarily the direct deployment) to use the new API for posting statuses
2. Uses the core APIKeyManager to get the API key - no more configuration needed
3. General cleanup/organization of component code
4. Adds some logging for indirect deployment polling